### PR TITLE
Handle upside down device orientation

### DIFF
--- a/ImageSegmenter/Services/CameraService.swift
+++ b/ImageSegmenter/Services/CameraService.swift
@@ -340,11 +340,18 @@ extension UIImage.Orientation {
     switch deviceOrientation {
     case .portrait:
       return .up
+    case .portraitUpsideDown:
+      // When the device is upside down we need to rotate the image 180 degrees
+      // otherwise the image will be processed as if it were upright which
+      // results in incorrect landmark and segmentation coordinates.
+      return .down
     case .landscapeLeft:
       return .left
     case .landscapeRight:
       return .right
     default:
+      // Treat all other orientations (face up, face down, unknown) as the
+      // default `.up` orientation.
       return .up
     }
   }


### PR DESCRIPTION
## Summary
- add explicit mapping for `.portraitUpsideDown` in image orientation helper
- document fallback handling for other orientations

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1e97aa2483318c4d4ecb0addc8cc