### PR TITLE
Add default return for empty pixel arrays in weightedAverage

### DIFF
--- a/ImageSegmenter/Utils/ColorExtractor+Utils.swift
+++ b/ImageSegmenter/Utils/ColorExtractor+Utils.swift
@@ -60,6 +60,10 @@ extension ColorExtractor {
 
     // MARK: Statistics --------------------------------------------------
     static func weightedAverage(_ pixels: [Pixel]) -> Pixel {
+        guard !pixels.isEmpty else {
+            // Default to black when no pixels are provided to avoid division by zero
+            return (0, 0, 0)
+        }
         let cnt = Float(pixels.count)
         let sums = pixels.reduce((0, 0, 0)) { res, px in
             (res.0 + px.r, res.1 + px.g, res.2 + px.b)


### PR DESCRIPTION
## Summary
- prevent divide-by-zero by returning `(0,0,0)` when `weightedAverage` receives an empty pixel array
- document empty-array handling in `weightedAverage`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d35ed08dc8331bca806c4a216f9bc