### PR TITLE
Add full palette explorer and highlight recommended colors

### DIFF
--- a/ImageSegmenter/Models/PersonalizedSeasonData.swift
+++ b/ImageSegmenter/Models/PersonalizedSeasonData.swift
@@ -88,17 +88,20 @@ struct ColorItem: Codable, Identifiable {
     let hexValue: String
     let usageContext: String
     let harmonyReason: String
+    var isRecommended: Bool
 
     init(id: UUID = UUID(),
          name: String,
          hexValue: String,
          usageContext: String,
-         harmonyReason: String) {
+         harmonyReason: String,
+         isRecommended: Bool = false) {
         self.id = id
         self.name = name
         self.hexValue = hexValue
         self.usageContext = usageContext
         self.harmonyReason = harmonyReason
+        self.isRecommended = isRecommended
     }
 
     /// Normalized hex value (lowercase with #)

--- a/ImageSegmenter/Services/ColorDatabaseManager.swift
+++ b/ImageSegmenter/Services/ColorDatabaseManager.swift
@@ -263,7 +263,7 @@ struct ColorData: Codable, Identifiable {
     }
 
     /// Convert to ColorItem for use in PersonalizedSeasonData
-    func toColorItem(usageContext: String = "", harmonyReason: String = "") -> ColorItem {
+    func toColorItem(usageContext: String = "", harmonyReason: String = "", isRecommended: Bool = false) -> ColorItem {
         let context = usageContext.isEmpty ? "Perfect for \(category.lowercased()) in \(season)" : usageContext
         let reason = harmonyReason.isEmpty ? "Harmonizes beautifully with \(season) characteristics" : harmonyReason
 
@@ -271,7 +271,8 @@ struct ColorData: Codable, Identifiable {
             name: name,
             hexValue: normalizedHex,
             usageContext: context,
-            harmonyReason: reason
+            harmonyReason: reason,
+            isRecommended: isRecommended
         )
     }
 }

--- a/ImageSegmenter/ViewModels/PersonalizedSeasonViewModel.swift
+++ b/ImageSegmenter/ViewModels/PersonalizedSeasonViewModel.swift
@@ -407,6 +407,52 @@ class PersonalizedSeasonViewModel: ObservableObject {
         }
     }
 
+    /// Get full palette colors for all seasons in the user's DNA
+    /// - Returns: Array of ColorItem representing the complete palette
+    func getFullPaletteColors() -> [ColorItem] {
+        let colorDB = ColorDatabaseManager.shared
+        var combinedColors: [ColorData] = []
+
+        // Always include primary season colors
+        combinedColors.append(contentsOf: colorDB.getColors(for: seasonDNA.primary.season))
+
+        // Include secondary and tertiary if available
+        if let secondary = seasonDNA.secondary?.season {
+            combinedColors.append(contentsOf: colorDB.getColors(for: secondary))
+        }
+
+        if let tertiary = seasonDNA.tertiary?.season {
+            combinedColors.append(contentsOf: colorDB.getColors(for: tertiary))
+        }
+
+        // Build set of recommended color hex values for highlighting
+        var recommendedHexes: Set<String> = []
+        if personalizedData.hasEnhancedColorData,
+           let enhanced = personalizedData.enhancedColorData {
+            let recommendedItems = enhanced.bestNeutrals.colors +
+                                  enhanced.bestAccents.colors +
+                                  enhanced.bestBaseColors.colors
+            recommendedHexes = Set(recommendedItems.map { $0.normalizedHex })
+        } else {
+            let hexes = bestNeutrals.colors + bestAccents.colors + bestBaseColors.colors
+            recommendedHexes = Set(hexes.map { normalizeHex($0) })
+        }
+
+        // Convert to ColorItems, marking those that are recommended
+        var seenHexes: Set<String> = []
+        var colorItems: [ColorItem] = []
+
+        for colorData in combinedColors {
+            let normalized = colorData.normalizedHex
+            if seenHexes.contains(normalized) { continue }
+            seenHexes.insert(normalized)
+            let isRecommended = recommendedHexes.contains(normalized)
+            colorItems.append(colorData.toColorItem(isRecommended: isRecommended))
+        }
+
+        return colorItems
+    }
+
     // MARK: - Private Helper Methods
 
     private func createColorItemFromHex(_ hexValue: String, isAvoidColor: Bool = false) -> ColorItem? {
@@ -485,6 +531,12 @@ class PersonalizedSeasonViewModel: ObservableObject {
         } else {
             return "Perfect match for your pure \(seasonDNA.primary.season) coloring"
         }
+    }
+
+    /// Normalize a hex string to include leading '#' and lowercase letters
+    private func normalizeHex(_ hex: String) -> String {
+        let cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return cleaned.hasPrefix("#") ? cleaned : "#\(cleaned)"
     }
 
 }

--- a/ImageSegmenter/Views/PersonalizedSeasonView.swift
+++ b/ImageSegmenter/Views/PersonalizedSeasonView.swift
@@ -206,7 +206,9 @@ struct PersonalizedSeasonView: View {
                         columns: 4
                     )
                     .padding(.top)
-                        
+
+                    SeasonPaletteExplorerView(colorItems: viewModel.getFullPaletteColors())
+                        .padding(.top)
                 }
             } else {
                 // Fallback to basic color display
@@ -216,6 +218,9 @@ struct PersonalizedSeasonView: View {
                     colorItems: createBasicColorItems(from: viewModel.personalizedData.emphasizedColors),
                     columns: 4
                 )
+
+                SeasonPaletteExplorerView(colorItems: viewModel.getFullPaletteColors())
+                    .padding(.top)
             }
 
             // Secondary EnhancedColorGrid for colors to avoid (if any)

--- a/ImageSegmenter/Views/SeasonPaletteExplorerView.swift
+++ b/ImageSegmenter/Views/SeasonPaletteExplorerView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct SeasonPaletteExplorerView: View {
+    let colorItems: [ColorItem]
+    private let columns: [GridItem]
+
+    init(colorItems: [ColorItem], columns: Int = 6) {
+        self.colorItems = colorItems
+        self.columns = Array(repeating: GridItem(.flexible()), count: columns)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Full Palette")
+                .font(.headline)
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 8) {
+                    ForEach(colorItems) { item in
+                        VStack(spacing: 4) {
+                            ZStack(alignment: .topTrailing) {
+                                Circle()
+                                    .fill(Color(hex: item.hexValue))
+                                    .frame(width: 40, height: 40)
+
+                                if item.isRecommended {
+                                    Image(systemName: "star.fill")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.yellow)
+                                        .offset(x: 6, y: -6)
+                                }
+                            }
+
+                            Text(item.name)
+                                .font(.caption2)
+                                .multilineTextAlignment(.center)
+                                .frame(width: 44)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 200)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `ColorItem` with `isRecommended` flag and propagate through `ColorDatabaseManager`
- add `getFullPaletteColors` to `PersonalizedSeasonViewModel` and integrate `SeasonPaletteExplorerView`
- new `SeasonPaletteExplorerView` shows all palette colors highlighting those in best recommendations

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d48f8de408331bd4aa562a57b06e1