### PR TITLE
Add full palette explorer and highlight recommended colors

### DIFF
--- a/ImageSegmenter.xcodeproj/project.pbxproj
+++ b/ImageSegmenter.xcodeproj/project.pbxproj
@@ -100,9 +100,10 @@
 		523113622DECCC3600FCFC91 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523113612DECCC3600FCFC91 /* Color+Extensions.swift */; };
 		523113652DECCC6A00FCFC91 /* PersonalizationService+DNAHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523113642DECCC6A00FCFC91 /* PersonalizationService+DNAHelpers.swift */; };
 		523113662DECCC6A00FCFC91 /* ColorDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523113632DECCC6A00FCFC91 /* ColorDatabaseManager.swift */; };
-		523113692DED03C800FCFC91 /* SeasonDNARingChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523113682DED03C800FCFC91 /* SeasonDNARingChart.swift */; };
-		5231136A2DED03C800FCFC91 /* EnhancedColorGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523113672DED03C800FCFC91 /* EnhancedColorGrid.swift */; };
-		52774D712E14BFFB00309149 /* MockPersonalizedSeasonGuide.md in Resources */ = {isa = PBXBuildFile; fileRef = 52774D702E14BFFA00309149 /* MockPersonalizedSeasonGuide.md */; };
+                523113692DED03C800FCFC91 /* SeasonDNARingChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523113682DED03C800FCFC91 /* SeasonDNARingChart.swift */; };
+                5231136A2DED03C800FCFC91 /* EnhancedColorGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523113672DED03C800FCFC91 /* EnhancedColorGrid.swift */; };
+                5231136C2DED03C800FCFC91 /* SeasonPaletteExplorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5231136B2DED03C800FCFC91 /* SeasonPaletteExplorerView.swift */; };
+                52774D712E14BFFB00309149 /* MockPersonalizedSeasonGuide.md in Resources */ = {isa = PBXBuildFile; fileRef = 52774D702E14BFFA00309149 /* MockPersonalizedSeasonGuide.md */; };
 		52774D742E14C01A00309149 /* MockPersonalizedSeasonDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52774D732E14C01A00309149 /* MockPersonalizedSeasonDataFactory.swift */; };
 		52774D752E14C01A00309149 /* DebugPersonalizedSeasonHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52774D722E14C01A00309149 /* DebugPersonalizedSeasonHelper.swift */; };
 		52774D772E28822100309149 /* MetalRecommendation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52774D762E28822100309149 /* MetalRecommendation.swift */; };
@@ -243,9 +244,10 @@
 		523113612DECCC3600FCFC91 /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		523113632DECCC6A00FCFC91 /* ColorDatabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDatabaseManager.swift; sourceTree = "<group>"; };
 		523113642DECCC6A00FCFC91 /* PersonalizationService+DNAHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersonalizationService+DNAHelpers.swift"; sourceTree = "<group>"; };
-		523113672DED03C800FCFC91 /* EnhancedColorGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedColorGrid.swift; sourceTree = "<group>"; };
-		523113682DED03C800FCFC91 /* SeasonDNARingChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonDNARingChart.swift; sourceTree = "<group>"; };
-		52774D702E14BFFA00309149 /* MockPersonalizedSeasonGuide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = MockPersonalizedSeasonGuide.md; sourceTree = "<group>"; };
+                523113672DED03C800FCFC91 /* EnhancedColorGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedColorGrid.swift; sourceTree = "<group>"; };
+                523113682DED03C800FCFC91 /* SeasonDNARingChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonDNARingChart.swift; sourceTree = "<group>"; };
+                5231136B2DED03C800FCFC91 /* SeasonPaletteExplorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonPaletteExplorerView.swift; sourceTree = "<group>"; };
+                52774D702E14BFFA00309149 /* MockPersonalizedSeasonGuide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = MockPersonalizedSeasonGuide.md; sourceTree = "<group>"; };
 		52774D722E14C01A00309149 /* DebugPersonalizedSeasonHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPersonalizedSeasonHelper.swift; sourceTree = "<group>"; };
 		52774D732E14C01A00309149 /* MockPersonalizedSeasonDataFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPersonalizedSeasonDataFactory.swift; sourceTree = "<group>"; };
 		52774D762E28822100309149 /* MetalRecommendation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalRecommendation.swift; sourceTree = "<group>"; };
@@ -504,9 +506,10 @@
 				52774D782E28823E00309149 /* MetallicColorDisplay.swift */,
 				52774D792E28823E00309149 /* PersonalizedMetalsGrid.swift */,
 				523113672DED03C800FCFC91 /* EnhancedColorGrid.swift */,
-				523113682DED03C800FCFC91 /* SeasonDNARingChart.swift */,
-				523113462DE7F3C100FCFC91 /* PersonalizedSeasonView.swift */,
-				523112A92DD6D1D500FCFC91 /* DefaultSeasonView.swift */,
+                                523113682DED03C800FCFC91 /* SeasonDNARingChart.swift */,
+                                5231136B2DED03C800FCFC91 /* SeasonPaletteExplorerView.swift */,
+                                523113462DE7F3C100FCFC91 /* PersonalizedSeasonView.swift */,
+                                523112A92DD6D1D500FCFC91 /* DefaultSeasonView.swift */,
 				523112A72DD5CAA400FCFC91 /* LandingPageView.swift */,
 				5222FDEE2DD40FEF00EF3C65 /* AnalysisResultView.swift */,
 				5222FDEF2DD40FEF00EF3C65 /* DebugOverlayView.swift */,
@@ -831,10 +834,11 @@
 				52774D7D2E2F0D7A00309149 /* MockMetalRecommendations.swift in Sources */,
 				523113582DE7FF3000FCFC91 /* NotificationManager.swift in Sources */,
 				BF6EBB932B1EB75B00CD13FB /* MergeColorShaders.metal in Sources */,
-				523113692DED03C800FCFC91 /* SeasonDNARingChart.swift in Sources */,
-				5231136A2DED03C800FCFC91 /* EnhancedColorGrid.swift in Sources */,
-                            5231129E2DD4E5E900FCFC91 /* FrameQualityEvaluator.swift in Sources */,
-				5222FDF22DD40FEF00EF3C65 /* FrameQualityIndicatorView.swift in Sources */,
+                                523113692DED03C800FCFC91 /* SeasonDNARingChart.swift in Sources */,
+                                5231136A2DED03C800FCFC91 /* EnhancedColorGrid.swift in Sources */,
+                                5231136C2DED03C800FCFC91 /* SeasonPaletteExplorerView.swift in Sources */,
+                                5231129E2DD4E5E900FCFC91 /* FrameQualityEvaluator.swift in Sources */,
+                                5222FDF22DD40FEF00EF3C65 /* FrameQualityIndicatorView.swift in Sources */,
 				5222FDF32DD40FEF00EF3C65 /* DebugOverlayView.swift in Sources */,
 				5222FE272DD46C4C00EF3C65 /* PixelBufferPoolManager.swift in Sources */,
 				5222FDF42DD40FEF00EF3C65 /* AnalysisResultView.swift in Sources */,

--- a/ImageSegmenter/Models/PersonalizedSeasonData.swift
+++ b/ImageSegmenter/Models/PersonalizedSeasonData.swift
@@ -88,17 +88,20 @@ struct ColorItem: Codable, Identifiable {
     let hexValue: String
     let usageContext: String
     let harmonyReason: String
+    var isRecommended: Bool
 
     init(id: UUID = UUID(),
          name: String,
          hexValue: String,
          usageContext: String,
-         harmonyReason: String) {
+         harmonyReason: String,
+         isRecommended: Bool = false) {
         self.id = id
         self.name = name
         self.hexValue = hexValue
         self.usageContext = usageContext
         self.harmonyReason = harmonyReason
+        self.isRecommended = isRecommended
     }
 
     /// Normalized hex value (lowercase with #)

--- a/ImageSegmenter/Services/ColorDatabaseManager.swift
+++ b/ImageSegmenter/Services/ColorDatabaseManager.swift
@@ -263,7 +263,7 @@ struct ColorData: Codable, Identifiable {
     }
 
     /// Convert to ColorItem for use in PersonalizedSeasonData
-    func toColorItem(usageContext: String = "", harmonyReason: String = "") -> ColorItem {
+    func toColorItem(usageContext: String = "", harmonyReason: String = "", isRecommended: Bool = false) -> ColorItem {
         let context = usageContext.isEmpty ? "Perfect for \(category.lowercased()) in \(season)" : usageContext
         let reason = harmonyReason.isEmpty ? "Harmonizes beautifully with \(season) characteristics" : harmonyReason
 
@@ -271,7 +271,8 @@ struct ColorData: Codable, Identifiable {
             name: name,
             hexValue: normalizedHex,
             usageContext: context,
-            harmonyReason: reason
+            harmonyReason: reason,
+            isRecommended: isRecommended
         )
     }
 }

--- a/ImageSegmenter/ViewModels/PersonalizedSeasonViewModel.swift
+++ b/ImageSegmenter/ViewModels/PersonalizedSeasonViewModel.swift
@@ -407,6 +407,52 @@ class PersonalizedSeasonViewModel: ObservableObject {
         }
     }
 
+    /// Get full palette colors for all seasons in the user's DNA
+    /// - Returns: Array of ColorItem representing the complete palette
+    func getFullPaletteColors() -> [ColorItem] {
+        let colorDB = ColorDatabaseManager.shared
+        var combinedColors: [ColorData] = []
+
+        // Always include primary season colors
+        combinedColors.append(contentsOf: colorDB.getColors(for: seasonDNA.primary.season))
+
+        // Include secondary and tertiary if available
+        if let secondary = seasonDNA.secondary?.season {
+            combinedColors.append(contentsOf: colorDB.getColors(for: secondary))
+        }
+
+        if let tertiary = seasonDNA.tertiary?.season {
+            combinedColors.append(contentsOf: colorDB.getColors(for: tertiary))
+        }
+
+        // Build set of recommended color hex values for highlighting
+        var recommendedHexes: Set<String> = []
+        if personalizedData.hasEnhancedColorData,
+           let enhanced = personalizedData.enhancedColorData {
+            let recommendedItems = enhanced.bestNeutrals.colors +
+                                  enhanced.bestAccents.colors +
+                                  enhanced.bestBaseColors.colors
+            recommendedHexes = Set(recommendedItems.map { $0.normalizedHex })
+        } else {
+            let hexes = bestNeutrals.colors + bestAccents.colors + bestBaseColors.colors
+            recommendedHexes = Set(hexes.map { normalizeHex($0) })
+        }
+
+        // Convert to ColorItems, marking those that are recommended
+        var seenHexes: Set<String> = []
+        var colorItems: [ColorItem] = []
+
+        for colorData in combinedColors {
+            let normalized = colorData.normalizedHex
+            if seenHexes.contains(normalized) { continue }
+            seenHexes.insert(normalized)
+            let isRecommended = recommendedHexes.contains(normalized)
+            colorItems.append(colorData.toColorItem(isRecommended: isRecommended))
+        }
+
+        return colorItems
+    }
+
     // MARK: - Private Helper Methods
 
     private func createColorItemFromHex(_ hexValue: String, isAvoidColor: Bool = false) -> ColorItem? {
@@ -485,6 +531,12 @@ class PersonalizedSeasonViewModel: ObservableObject {
         } else {
             return "Perfect match for your pure \(seasonDNA.primary.season) coloring"
         }
+    }
+
+    /// Normalize a hex string to include leading '#' and lowercase letters
+    private func normalizeHex(_ hex: String) -> String {
+        let cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return cleaned.hasPrefix("#") ? cleaned : "#\(cleaned)"
     }
 
 }

--- a/ImageSegmenter/Views/PersonalizedSeasonView.swift
+++ b/ImageSegmenter/Views/PersonalizedSeasonView.swift
@@ -206,7 +206,9 @@ struct PersonalizedSeasonView: View {
                         columns: 4
                     )
                     .padding(.top)
-                        
+
+                    SeasonPaletteExplorerView(colorItems: viewModel.getFullPaletteColors())
+                        .padding(.top)
                 }
             } else {
                 // Fallback to basic color display
@@ -216,6 +218,9 @@ struct PersonalizedSeasonView: View {
                     colorItems: createBasicColorItems(from: viewModel.personalizedData.emphasizedColors),
                     columns: 4
                 )
+
+                SeasonPaletteExplorerView(colorItems: viewModel.getFullPaletteColors())
+                    .padding(.top)
             }
 
             // Secondary EnhancedColorGrid for colors to avoid (if any)

--- a/ImageSegmenter/Views/SeasonPaletteExplorerView.swift
+++ b/ImageSegmenter/Views/SeasonPaletteExplorerView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct SeasonPaletteExplorerView: View {
+    let colorItems: [ColorItem]
+    private let columns: [GridItem]
+
+    init(colorItems: [ColorItem], columns: Int = 6) {
+        self.colorItems = colorItems
+        self.columns = Array(repeating: GridItem(.flexible()), count: columns)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Full Palette")
+                .font(.headline)
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 8) {
+                    ForEach(colorItems) { item in
+                        VStack(spacing: 4) {
+                            ZStack(alignment: .topTrailing) {
+                                Circle()
+                                    .fill(Color(hex: item.hexValue))
+                                    .frame(width: 40, height: 40)
+
+                                if item.isRecommended {
+                                    Image(systemName: "star.fill")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.yellow)
+                                        .offset(x: 6, y: -6)
+                                }
+                            }
+
+                            Text(item.name)
+                                .font(.caption2)
+                                .multilineTextAlignment(.center)
+                                .frame(width: 44)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 200)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `ColorItem` with `isRecommended` flag and propagate through `ColorDatabaseManager`
- add `getFullPaletteColors` to `PersonalizedSeasonViewModel` and integrate `SeasonPaletteExplorerView`
- new `SeasonPaletteExplorerView` shows all palette colors highlighting those in best recommendations
- include `SeasonPaletteExplorerView` in Xcode project so builds recognize the new view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d48f8de408331bd4aa562a57b06e1